### PR TITLE
MySQLの認証方式をmysql_native_passwordに変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     image: mysql
     container_name: mysql
     restart: always
+    volumes:
+      - ./docker/mysql:/etc/mysql/conf.d
     environment:
       MYSQL_ROOT_PASSWORD: password
       TZ: 'Asia/Tokyo'

--- a/docker/mysql/default_authentication.cnf
+++ b/docker/mysql/default_authentication.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+default_authentication_plugin= mysql_native_password


### PR DESCRIPTION
Issue: #2 

## 概要
- MySQL 8系を使う場合、認証方式をcaching_sha2_password の認証形式に対応できない
- mysql_native_passwordに変更し、マウントする

## 参考リンク
- https://qiita.com/yensaki/items/9e453b7320ca2d0461c7